### PR TITLE
Redundant conda channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: nagios-plugins-s3
 channels:
  - conda-forge
- - anaconda
 dependencies:
  - pip
  - boto3


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

Minor comment, I think the `anaconda` channel in the conda environment is not required?

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
